### PR TITLE
Changed the endian that we send to network endian

### DIFF
--- a/controllers/nugus_controller/nugus_controller.cpp
+++ b/controllers/nugus_controller/nugus_controller.cpp
@@ -67,8 +67,8 @@ public:
             }
             else if (num_ready > 0) {
                 // Wire format
-                // unit32_t N   message size in bytes in network byte order
-                // uint8_t * N  the message
+                // unit32_t Nn  message size in bytes. The bytes are in network byte order (big endian)
+                // uint8_t * Nn  the message
                 uint32_t Nn;
                 if (recv(tcp_fd, &Nn, sizeof(Nn), 0) != sizeof(Nn)) {
                     std::cerr << "Error: Failed to read message size from TCP connection: " << strerror(errno)
@@ -76,7 +76,8 @@ public:
                     continue;
                 }
 
-				uint32_t Nh = ntohl(Nn);
+                // Covert to host endianness, which might be different to network endianness
+                uint32_t Nh = ntohl(Nn);
 
                 std::vector<uint8_t> data(Nh, 0);
                 if (recv(tcp_fd, data.data(), Nh, 0) != Nh) {
@@ -101,7 +102,7 @@ public:
                 data.resize(Nh);
                 msg.SerializeToArray(data.data(), Nh);
 
-				Nn = htonl(Nh);
+                Nn = htonl(Nh);
 
                 if (send(tcp_fd, &Nn, sizeof(Nn), 0) < 0) {
                     std::cerr << "Error: Failed to send data over TCP connection: " << strerror(errno) << std::endl;

--- a/controllers/nugus_controller/nugus_controller.cpp
+++ b/controllers/nugus_controller/nugus_controller.cpp
@@ -67,24 +67,26 @@ public:
             }
             else if (num_ready > 0) {
                 // Wire format
-                // unit64_t N   message size in bytes
+                // unit32_t N   message size in bytes in network byte order
                 // uint8_t * N  the message
-                uint64_t N;
-                if (recv(tcp_fd, &N, sizeof(N), 0) != sizeof(N)) {
+                uint32_t Nn;
+                if (recv(tcp_fd, &Nn, sizeof(Nn), 0) != sizeof(Nn)) {
                     std::cerr << "Error: Failed to read message size from TCP connection: " << strerror(errno)
                               << std::endl;
                     continue;
                 }
 
-                std::vector<uint8_t> data(N, 0);
-                if (recv(tcp_fd, data.data(), N, 0) != N) {
+				uint32_t Nh = ntohl(Nn);
+
+                std::vector<uint8_t> data(Nh, 0);
+                if (recv(tcp_fd, data.data(), Nh, 0) != Nh) {
                     std::cerr << "Error: Failed to read message from TCP connection: " << strerror(errno) << std::endl;
                     continue;
                 }
 
                 // Parse message data
                 controller::nugus::RobotControl msg;
-                if (!msg.ParseFromArray(data.data(), N)) {
+                if (!msg.ParseFromArray(data.data(), Nh)) {
                     std::cerr << "Error: Failed to parse serialised message" << std::endl;
                     continue;
                 }
@@ -95,11 +97,13 @@ public:
                 // Send a message to the client
                 msg.set_num(current_num);
 
-                N = msg.ByteSizeLong();
-                data.resize(N);
-                msg.SerializeToArray(data.data(), N);
+                Nh = msg.ByteSizeLong();
+                data.resize(Nh);
+                msg.SerializeToArray(data.data(), Nh);
 
-                if (send(tcp_fd, &N, sizeof(N), 0) < 0) {
+				Nn = htonl(Nh);
+
+                if (send(tcp_fd, &Nn, sizeof(Nn), 0) < 0) {
                     std::cerr << "Error: Failed to send data over TCP connection: " << strerror(errno) << std::endl;
                 }
                 else if (send(tcp_fd, data.data(), data.size(), 0) < 0) {

--- a/controllers/nugus_controller/nugus_controller_test.cpp
+++ b/controllers/nugus_controller/nugus_controller_test.cpp
@@ -177,7 +177,7 @@ int main(int argc, char** argv) {
             data.resize(Nh);
             msg.SerializeToArray(data.data(), Nh);
 
-            // Covert to network endianness, which might be different to network endianness
+            // Covert to network endianness, which might be different to host endianness
             Nn = htonl(Nh);
 
             if (send(tcp_fd, &Nn, sizeof(Nn), 0) < 0) {

--- a/controllers/nugus_controller/nugus_controller_test.cpp
+++ b/controllers/nugus_controller/nugus_controller_test.cpp
@@ -145,14 +145,14 @@ int main(int argc, char** argv) {
         }
         else if (num_ready > 0) {
             // Wire format
-            // unit32_t N   message size in bytes, in network endian order
-            // uint8_t * N  the message
+                // unit32_t Nn  message size in bytes. The bytes are in network byte order (big endian)
+            // uint8_t * Nn  the message
             if (recv(tcp_fd, &Nn, sizeof(Nn), 0) != sizeof(Nn)) {
                 std::cerr << "Error: Failed to read message size from TCP connection: " << strerror(errno) << std::endl;
                 continue;
             }
 
-			uint32_t Nh = ntohl(Nn);
+            uint32_t Nh = ntohl(Nn);
 
             if (recv(tcp_fd, data.data(), Nh, 0) != Nh) {
                 std::cerr << "Error: Failed to read message from TCP connection: " << strerror(errno) << std::endl;
@@ -177,7 +177,8 @@ int main(int argc, char** argv) {
             data.resize(Nh);
             msg.SerializeToArray(data.data(), Nh);
 
-			Nn = htonl(Nh);
+            // Covert to network endianness, which might be different to network endianness
+            Nn = htonl(Nh);
 
             if (send(tcp_fd, &Nn, sizeof(Nn), 0) < 0) {
                 std::cerr << "Error: Failed to send data over TCP connection: " << strerror(errno) << std::endl;
@@ -196,4 +197,3 @@ int main(int argc, char** argv) {
 
     return 0;
 }
-

--- a/controllers/nugus_controller/nugus_controller_test.cpp
+++ b/controllers/nugus_controller/nugus_controller_test.cpp
@@ -117,11 +117,13 @@ int main(int argc, char** argv) {
     controller::nugus::RobotControl msg;
     msg.set_num(current_num);
 
-    uint64_t N = msg.ByteSizeLong();
-    std::vector<uint8_t> data(N, 0);
-    msg.SerializeToArray(data.data(), N);
+    uint32_t Nh = msg.ByteSizeLong();
+    std::vector<uint8_t> data(Nh, 0);
+    msg.SerializeToArray(data.data(), Nh);
 
-    if (send(tcp_fd, &N, sizeof(N), 0) < 0) {
+	uint32_t Nn = htonl(Nh);
+
+    if (send(tcp_fd, &Nn, sizeof(Nn), 0) < 0) {
         std::cerr << "Error: Failed to send data over TCP connection: " << strerror(errno) << std::endl;
     }
     if (send(tcp_fd, data.data(), data.size(), 0) < 0) {
@@ -143,19 +145,21 @@ int main(int argc, char** argv) {
         }
         else if (num_ready > 0) {
             // Wire format
-            // unit64_t N   message size in bytes
+            // unit32_t N   message size in bytes, in network endian order
             // uint8_t * N  the message
-            if (recv(tcp_fd, &N, sizeof(N), 0) != sizeof(N)) {
+            if (recv(tcp_fd, &Nn, sizeof(Nn), 0) != sizeof(Nn)) {
                 std::cerr << "Error: Failed to read message size from TCP connection: " << strerror(errno) << std::endl;
                 continue;
             }
 
-            if (recv(tcp_fd, data.data(), N, 0) != N) {
+			uint32_t Nh = ntohl(Nn);
+
+            if (recv(tcp_fd, data.data(), Nh, 0) != Nh) {
                 std::cerr << "Error: Failed to read message from TCP connection: " << strerror(errno) << std::endl;
                 continue;
             }
 
-            if (!msg.ParseFromArray(data.data(), N)) {
+            if (!msg.ParseFromArray(data.data(), Nh)) {
                 std::cerr << "Error: Failed to parse serialised message" << std::endl;
                 continue;
             }
@@ -169,11 +173,13 @@ int main(int argc, char** argv) {
             current_num += 1;
             msg.set_num(current_num);
 
-            N = msg.ByteSizeLong();
-            data.resize(N);
-            msg.SerializeToArray(data.data(), N);
+            Nh = msg.ByteSizeLong();
+            data.resize(Nh);
+            msg.SerializeToArray(data.data(), Nh);
 
-            if (send(tcp_fd, &N, sizeof(N), 0) < 0) {
+			Nn = htonl(Nh);
+
+            if (send(tcp_fd, &Nn, sizeof(Nn), 0) < 0) {
                 std::cerr << "Error: Failed to send data over TCP connection: " << strerror(errno) << std::endl;
             }
             if (send(tcp_fd, data.data(), data.size(), 0) < 0) {


### PR DESCRIPTION
The webots repo uses network endian for sending the size of the messages. I've changed it to network endian on (my pr)[https://github.com/NUbots/NUbots/pull/394] so I suppose it should be changed here also.