### PR TITLE
Adds ASan and UBSan as build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,21 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS
 # We use nested namespaces which are not available before C++17
 set(CMAKE_CXX_STANDARD 17)
 
+# Enable address sanitizer
+option(USE_ASAN "Enable address sanitization" OFF)
+if(USE_ASAN)
+  add_compile_options(-fsanitize=address -fno-omit-frame-pointer -U_FORTIFY_SOURCE -fno-common)
+  add_link_options(-fsanitize=address)
+  link_libraries(asan)
+endif()
+
+option(USE_UBSAN "Enable undefined behaviour sanitization" OFF)
+if(USE_UBSAN)
+  add_compile_options(-fsanitize=undefined -fno-sanitize-recover=all)
+  add_link_options(-fsanitize=undefined)
+  link_libraries(ubsan)
+endif()
+
 # If WEBOTS_HOME is not already set, set it to the value of the WEBOTS_HOME environment variable. If the environment
 # variable is not defined, then choose some sort of sane default
 if(NOT DEFINED WEBOTS_HOME)


### PR DESCRIPTION
Address sanitizer and undefined behaviour sanitizer can be useful in finding and debugging buggy code.
This PR adds options to the cmake configuration to enable them.
I have tested these by using `ldd` on `nugus_controller`, and `ldd` reports that `nugus_controller` is linked to the sanitizers if they are enabled.