### PR TITLE
Ignore files webots generates when converting a NUgus to base nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 protos/**/*.cache
 worlds/.*.wbproj
 
+# Generated when converting a NUgus to base nodes
+worlds/NUgus_textures
+worlds/robot
+
 # Build files and binaries
 build/
 data/


### PR DESCRIPTION
Converting a NUgus to base nodes in webots generates `worlds/NUgus_textures` and `worlds/robot`, which we don't want to commit.