### PR TITLE
Change the default controller of the NUgus robot

### DIFF
--- a/protos/robot/NUgus.proto
+++ b/protos/robot/NUgus.proto
@@ -7,7 +7,7 @@ PROTO NUgus [
   field  SFVec3f     translation          0 0 0
   field  SFRotation  rotation             0 1 0 0
   field  SFString    name                 "NUgus"            # Is `Robot.name`.
-  field  SFString    controller           "void"             # Is `Robot.controller`.
+  field  SFString    controller           "player"             # Is `Robot.controller`.
   field  MFString    controllerArgs       []                 # Is `Robot.controllerArgs`.
   field  SFString    customData           ""                 # Is `Robot.customData`.
   field  SFBool      supervisor           FALSE              # Is `Robot.supervisor`.

--- a/protos/robot/NUgus.proto
+++ b/protos/robot/NUgus.proto
@@ -7,7 +7,7 @@ PROTO NUgus [
   field  SFVec3f     translation          0 0 0
   field  SFRotation  rotation             0 1 0 0
   field  SFString    name                 "NUgus"            # Is `Robot.name`.
-  field  SFString    controller           "player"             # Is `Robot.controller`.
+  field  SFString    controller           "player"           # Find in "webots/projects/samples/contests/robocup/controllers/player"
   field  MFString    controllerArgs       []                 # Is `Robot.controllerArgs`.
   field  SFString    customData           ""                 # Is `Robot.customData`.
   field  SFBool      supervisor           FALSE              # Is `Robot.supervisor`.


### PR DESCRIPTION
Currently it is `void`, which means in the official RoboCup setup, the robot loads the void controller. It should by default try to load the player controller.