### PR TITLE
Add in missing MX64-vel and MX106-vel in maxVelocity of motors

### DIFF
--- a/protos/robot/NUgus.proto
+++ b/protos/robot/NUgus.proto
@@ -101,7 +101,7 @@ PROTO NUgus [
         device [
           RotationalMotor {
             name "right_shoulder_pitch [shoulder]"
-            maxVelocity 8.16814
+            maxVelocity IS MX64-vel
             minPosition -3.14159265359
             maxPosition 3.14159265359
             maxTorque IS MX64-torque
@@ -320,7 +320,7 @@ PROTO NUgus [
         device [
           RotationalMotor {
             name "left_shoulder_pitch [shoulder]"
-            maxVelocity 8.16814
+            maxVelocity IS MX64-vel
             minPosition -3.14159265359
             maxPosition 3.14159265359
             maxTorque IS MX64-torque
@@ -568,7 +568,7 @@ PROTO NUgus [
               device [
                 RotationalMotor {
                   name "right_hip_roll [hip]"
-                  maxVelocity 5.75959
+                  maxVelocity IS MX106-vel
                   minPosition -3.14159265359
                   maxPosition 3.14159265359
                   maxTorque IS MX106-torque
@@ -1033,7 +1033,7 @@ PROTO NUgus [
               device [
                 RotationalMotor {
                   name "left_hip_roll [hip]"
-                  maxVelocity 5.75959
+                  maxVelocity IS MX106-vel
                   minPosition -3.14159265359
                   maxPosition 3.14159265359
                   maxTorque IS MX106-torque
@@ -1123,7 +1123,7 @@ PROTO NUgus [
                                 device [
                                   RotationalMotor {
                                     name "left_ankle_pitch"
-                                    maxVelocity 5.75959
+                                    maxVelocity IS MX106-vel
                                     minPosition -3.14159265359
                                     maxPosition 3.14159265359
                                     maxTorque 10.0


### PR DESCRIPTION
Looks like they were missed when adding them in initially.