### PR TITLE
Change the robot height in kid.wbt

### DIFF
--- a/worlds/kid.wbt
+++ b/worlds/kid.wbt
@@ -66,7 +66,7 @@ DEF RED_1 Darwin-opHinge2 {
 }
 
 DEF RED_2 NUgus {
-  translation -2.207 -0.71576 0.517
+  translation -2.207 -0.71576 0.51
   name "red player 2"
 }
 
@@ -85,7 +85,7 @@ DEF RED_4 Wolfgang {
 }
 DEF BLUE_1 NUgus {
   name "blue player 1"
-  translation 2.688 -0.3985 0.5249
+  translation 2.688 -0.3985 0.51
   rotation 0 0 1 3.1415
   controller "nugus_controller"
   controllerArgs [


### PR DESCRIPTION
The height that the robot is dropped into the world is problematic for running our code on. It gives a negative z acceleration which makes the robot immediately get up. This height change works ok, with no get up triggered. This is also the height as defined in our team config for RoboCup.