### PR TITLE
Adds center of mass to physics node of touch sensors

### DIFF
--- a/protos/robot/NUgus.proto
+++ b/protos/robot/NUgus.proto
@@ -733,6 +733,7 @@ PROTO NUgus [
                                             physics DEF touch_physics Physics{
                                               density -1
                                               mass 0.02
+                                              centerOfMass 0.0 0.0 0.0
                                             }
                                             # Sensor Type
                                             # Bumper returns a 1 when collision is detected


### PR DESCRIPTION
We didn't have any center of mass so the automatic marking tool gave us warnings. This PR fixes this so we have a COM on the touch sensors. It's put to [0 0 0] because they are so small the actual position shouldn't be an issue.