### PR TITLE
Reduce hip cylinder radius

### DIFF
--- a/protos/robot/NUgus.proto
+++ b/protos/robot/NUgus.proto
@@ -958,7 +958,7 @@ PROTO NUgus [
                 children [
                   Cylinder {
                     height 0.03
-                    radius 0.054
+                    radius 0.046
                   }
                 ]
               }
@@ -1401,7 +1401,7 @@ PROTO NUgus [
                 children [
                   Cylinder {
                     height 0.03
-                    radius 0.054
+                    radius 0.046
                   }
                 ]
               }

--- a/protos/robot/NUgus.proto
+++ b/protos/robot/NUgus.proto
@@ -953,12 +953,12 @@ PROTO NUgus [
           boundingObject Group {
             children [
               Transform {
-                translation 0.0 0.0 -0.015
+                translation 0.005 0.0 -0.015
                 rotation 1.0 0.0 0.0 1.5707963267948966
                 children [
                   Cylinder {
                     height 0.03
-                    radius 0.046
+                    radius 0.045
                   }
                 ]
               }
@@ -1396,12 +1396,12 @@ PROTO NUgus [
           boundingObject Group {
             children [
               Transform {
-                translation 0.0 0.0 -0.015
+                translation -0.005 0.0 -0.015
                 rotation 1.0 0.0 0.0 1.5707963267948966
                 children [
                   Cylinder {
                     height 0.03
-                    radius 0.046
+                    radius 0.045
                   }
                 ]
               }


### PR DESCRIPTION
This PR reduces the radius of the cylinder bounding box.

![image](https://user-images.githubusercontent.com/41043317/120595076-2bd4e880-c485-11eb-94c6-ec04c001399b.png)
