### PR TITLE
Shift lower leg bounding box

### DIFF
--- a/protos/robot/NUgus.proto
+++ b/protos/robot/NUgus.proto
@@ -843,29 +843,29 @@ PROTO NUgus [
                             boundingObject Group {
                               children [
                                 Transform {
-                                  translation 0 0 -0.0575
+                                  translation 0 0 -0.053
                                   rotation 1.0 0.0 0.0 0.1745327073427288
                                   children [
                                     Box {
-                                      size 0.06 0.065 0.165
+                                      size 0.06 0.065 0.14
                                     }
                                   ]
                                 }
                                 Transform {
-                                  translation -0.0275 0.029500000000000002 -0.1725
+                                  translation -0.0275 0.019500000000000002 -0.1625
                                   rotation 1.0 0.0 0.0 0.1745327073427288
                                   children [
                                     Box {
-                                      size 0.005 0.065 0.065
+                                      size 0.005 0.065 0.08
                                     }
                                   ]
                                 }
                                 Transform {
-                                  translation 0.0275 0.029500000000000002 -0.1725
+                                  translation 0.0275 0.019500000000000002 -0.1625
                                   rotation 1.0 0.0 0.0 0.1745327073427288
                                   children [
                                     Box {
-                                      size 0.005 0.065 0.065
+                                      size 0.005 0.065 0.08
                                     }
                                   ]
                                 }
@@ -1286,29 +1286,29 @@ PROTO NUgus [
                             boundingObject Group {
                               children [
                                 Transform {
-                                  translation 0 0 -0.0575
+                                  translation 0 0 -0.053
                                   rotation 1.0 0.0 0.0 0.1745327073427288
                                   children [
                                     Box {
-                                      size 0.06 0.065 0.165
+                                      size 0.06 0.065 0.14
                                     }
                                   ]
                                 }
                                 Transform {
-                                  translation -0.0275 0.029500000000000002 -0.1725
+                                  translation -0.0275 0.019500000000000002 -0.1625
                                   rotation 1.0 0.0 0.0 0.1745327073427288
                                   children [
                                     Box {
-                                      size 0.005 0.065 0.065
+                                      size 0.005 0.065 0.08
                                     }
                                   ]
                                 }
                                 Transform {
-                                  translation 0.0275 0.029500000000000002 -0.1725
+                                  translation 0.0275 0.019500000000000002 -0.1625
                                   rotation 1.0 0.0 0.0 0.1745327073427288
                                   children [
                                     Box {
-                                      size 0.005 0.065 0.065
+                                      size 0.005 0.065 0.08
                                     }
                                   ]
                                 }


### PR DESCRIPTION
This PR raises the lower leg bounding box to hopefully prevent self collisions in the ankles. 

![image](https://user-images.githubusercontent.com/41043317/120604882-d272b680-c490-11eb-9240-9c3df939d354.png)
