### PR TITLE
Change to using capsules for the bounding box for the cleats

### DIFF
--- a/protos/robot/NUgus.proto
+++ b/protos/robot/NUgus.proto
@@ -1220,29 +1220,43 @@ PROTO NUgus [
                                         boundingObject Group {
                                           children [
                                             Transform {
-                                              translation 0.010500000000000002 0.037500000000000006 -0.023
+                                              translation 0.010500000000000002 0.037500000000000006 -0.011999999999999997
                                               rotation 0.0 0.0 1.0 0.0
                                               children [
                                                 Box {
-                                                  size 0.125 0.025 0.078
+                                                  size 0.125 0.025 0.068
                                                 }
                                               ]
                                             }
                                             Transform {
-                                              translation 0.011000000000000003 -0.128 -0.033
+                                              translation 0.010500000000000002 -0.027999999999999997 -0.0385
                                               rotation 0.0 0.0 1.0 0.0
                                               children [
                                                 Box {
-                                                  size 0.132 0.08 0.058
+                                                  size 0.125 0.12 0.015
                                                 }
                                               ]
                                             }
                                             Transform {
-                                              translation 0.010500000000000002 -0.027999999999999997 -0.0495
+                                              translation 0.010500000000000002 -0.11550000000000002 -0.017499999999999998
                                               rotation 0.0 0.0 1.0 0.0
                                               children [
                                                 Box {
-                                                  size 0.125 0.12 0.025
+                                                  size 0.125 0.105 0.057
+                                                }
+                                              ]
+                                            }
+                                            Transform {
+                                              translation 0.041 0.025 -0.051
+                                              rotation 0.0 1 0 -1.571
+                                              children [
+                                                Capsule {
+                                                  bottom      TRUE   # {TRUE, FALSE}
+                                                  height      0.005      # [0, inf)
+                                                  radius      0.005      # [0, inf)
+                                                  side        TRUE   # {TRUE, FALSE}
+                                                  top         FALSE  # {TRUE, FALSE}
+                                                  subdivision 12     # [3, inf)
                                                 }
                                               ]
                                             }

--- a/protos/robot/NUgus.proto
+++ b/protos/robot/NUgus.proto
@@ -790,7 +790,7 @@ PROTO NUgus [
                                               rotation 0.0 0.0 1.0 0.0
                                               children [
                                                 Box {
-                                                  size 0.132 0.08 0.05
+                                                  size  0.125 0.08 0.05
                                                 }
                                               ]
                                             }
@@ -1276,29 +1276,29 @@ PROTO NUgus [
                                         boundingObject Group {
                                           children [
                                             Transform {
-                                              translation 0.010500000000000002 0.037500000000000006 -0.011999999999999997
+                                              translation 0.0105 0.037 -0.017
                                               rotation 0.0 0.0 1.0 0.0
                                               children [
                                                 Box {
-                                                  size 0.125 0.025 0.068
+                                                  size 0.125 0.0175 0.0585
                                                 }
                                               ]
                                             }
                                             Transform {
-                                              translation 0.010500000000000002 -0.027999999999999997 -0.0385
+                                              translation 0.011 -0.128 -0.02
                                               rotation 0.0 0.0 1.0 0.0
                                               children [
                                                 Box {
-                                                  size 0.125 0.12 0.015
+                                                  size 0.125 0.08 0.05
                                                 }
                                               ]
                                             }
                                             Transform {
-                                              translation 0.010500000000000002 -0.11550000000000002 -0.017499999999999998
+                                              translation 0.011 -0.028 -0.035
                                               rotation 0.0 0.0 1.0 0.0
                                               children [
                                                 Box {
-                                                  size 0.125 0.105 0.057
+                                                  size 0.125 0.12 0.01875
                                                 }
                                               ]
                                             }

--- a/protos/robot/NUgus.proto
+++ b/protos/robot/NUgus.proto
@@ -777,29 +777,85 @@ PROTO NUgus [
                                         boundingObject Group {
                                           children [
                                             Transform {
-                                              translation -0.010500000000000002 0.037500000000000006 -0.023
+                                              translation -0.0105 0.037 -0.017
                                               rotation 0.0 0.0 1.0 0.0
                                               children [
                                                 Box {
-                                                  size 0.125 0.025 0.078
+                                                  size 0.125 0.0175 0.0585
                                                 }
                                               ]
                                             }
                                             Transform {
-                                              translation -0.011000000000000003 -0.128 -0.033
+                                              translation -0.011 -0.128 -0.013
                                               rotation 0.0 0.0 1.0 0.0
                                               children [
                                                 Box {
-                                                  size 0.132 0.08 0.058
+                                                  size 0.132 0.08 0.05
                                                 }
                                               ]
                                             }
                                             Transform {
-                                              translation -0.010500000000000002 -0.027999999999999997 -0.0495
+                                              translation -0.011 -0.028 -0.035
                                               rotation 0.0 0.0 1.0 0.0
                                               children [
                                                 Box {
-                                                  size 0.125 0.12 0.025
+                                                  size 0.125 0.12 0.01875
+                                                }
+                                              ]
+                                            }
+                                           Transform {
+                                              translation -0.057 0.024 -0.056
+                                              rotation -1.0 0.0 0.0 -1.54
+                                              children [
+                                                Capsule {
+                                                  bottom      TRUE   # {TRUE, FALSE}
+                                                  height      0.001      # [0, inf)
+                                                  radius      0.009      # [0, inf)
+                                                  side        TRUE   # {TRUE, FALSE}
+                                                  top         FALSE  # {TRUE, FALSE}
+                                                  subdivision 12     # [3, inf)
+                                                }
+                                              ]
+                                            }
+                                            Transform {
+                                              translation 0.041 0.025 -0.056
+                                              rotation -1.0 0.0 0.0 -1.54
+                                              children [
+                                                Capsule {
+                                                  bottom      TRUE   # {TRUE, FALSE}
+                                                  height      0.001      # [0, inf)
+                                                  radius      0.009      # [0, inf)
+                                                  side        TRUE   # {TRUE, FALSE}
+                                                  top         FALSE  # {TRUE, FALSE}
+                                                  subdivision 12     # [3, inf)
+                                                }
+                                              ]
+                                            }
+                                            Transform {
+                                              translation -0.057 -0.154 -0.056
+                                              rotation -1.0 0.0 0.0 -1.54
+                                              children [
+                                                Capsule {
+                                                  bottom      TRUE   # {TRUE, FALSE}
+                                                  height      0.001      # [0, inf)
+                                                  radius      0.009      # [0, inf)
+                                                  side        TRUE   # {TRUE, FALSE}
+                                                  top         FALSE  # {TRUE, FALSE}
+                                                  subdivision 12     # [3, inf)
+                                                }
+                                              ]
+                                            }
+                                            Transform {
+                                              translation 0.041 -0.154 -0.056
+                                              rotation -1.0 0.0 0.0 -1.54
+                                              children [
+                                                Capsule {
+                                                  bottom      TRUE   # {TRUE, FALSE}
+                                                  height      0.001      # [0, inf)
+                                                  radius      0.009      # [0, inf)
+                                                  side        TRUE   # {TRUE, FALSE}
+                                                  top         FALSE  # {TRUE, FALSE}
+                                                  subdivision 12     # [3, inf)
                                                 }
                                               ]
                                             }
@@ -1247,13 +1303,55 @@ PROTO NUgus [
                                               ]
                                             }
                                             Transform {
-                                              translation 0.041 0.025 -0.051
-                                              rotation 0.0 1 0 -1.571
+                                              translation 0.057 0.024 -0.056
+                                              rotation -1.0 0.0 0.0 -1.54
                                               children [
                                                 Capsule {
                                                   bottom      TRUE   # {TRUE, FALSE}
-                                                  height      0.005      # [0, inf)
-                                                  radius      0.005      # [0, inf)
+                                                  height      0.001      # [0, inf)
+                                                  radius      0.009      # [0, inf)
+                                                  side        TRUE   # {TRUE, FALSE}
+                                                  top         FALSE  # {TRUE, FALSE}
+                                                  subdivision 12     # [3, inf)
+                                                }
+                                              ]
+                                            }
+                                            Transform {
+                                              translation -0.04 0.025 -0.056
+                                              rotation -1.0 0.0 0.0 -1.54
+                                              children [
+                                                Capsule {
+                                                  bottom      TRUE   # {TRUE, FALSE}
+                                                  height      0.001      # [0, inf)
+                                                  radius      0.009      # [0, inf)
+                                                  side        TRUE   # {TRUE, FALSE}
+                                                  top         FALSE  # {TRUE, FALSE}
+                                                  subdivision 12     # [3, inf)
+                                                }
+                                              ]
+                                            }
+                                            Transform {
+                                              translation -0.04 -0.154 -0.056
+                                              rotation -1.0 0.0 0.0 -1.54
+                                              children [
+                                                Capsule {
+                                                  bottom      TRUE   # {TRUE, FALSE}
+                                                  height      0.001      # [0, inf)
+                                                  radius      0.009      # [0, inf)
+                                                  side        TRUE   # {TRUE, FALSE}
+                                                  top         FALSE  # {TRUE, FALSE}
+                                                  subdivision 12     # [3, inf)
+                                                }
+                                              ]
+                                            }
+                                            Transform {
+                                              translation 0.057 -0.154 -0.056
+                                              rotation -1.0 0.0 0.0 -1.54
+                                              children [
+                                                Capsule {
+                                                  bottom      TRUE   # {TRUE, FALSE}
+                                                  height      0.001      # [0, inf)
+                                                  radius      0.009      # [0, inf)
                                                   side        TRUE   # {TRUE, FALSE}
                                                   top         FALSE  # {TRUE, FALSE}
                                                   subdivision 12     # [3, inf)

--- a/protos/robot/NUgus.proto
+++ b/protos/robot/NUgus.proto
@@ -721,14 +721,24 @@ PROTO NUgus [
                                                     url IS robotTexture
                                                   }
                                                 }
-                                                geometry DEF touch_box Box {
-                                                  size 0.01 0.01 0.005
-                                                }
                                               }
                                             ]
                                             name "right_touch_sensor_br"
                                             # Bounding object uses geometry from touch_shape
-                                            boundingObject USE touch_box
+                                            boundingObject DEF touch_box Transform {
+                                              translation 0.0 0.0 0.0056
+                                              rotation -1.0 0.0 0.0 -1.54
+                                              children [
+                                                Capsule {
+                                                  bottom      TRUE   # {TRUE, FALSE}
+                                                  height      0.001  # [0, inf)
+                                                  radius      0.009  # [0, inf)
+                                                  side        TRUE   # {TRUE, FALSE}
+                                                  top         FALSE  # {TRUE, FALSE}
+                                                  subdivision 12     # [3, inf)
+                                                }
+                                              ]
+                                            }
                                             # Define physics for all touch sensors
                                             physics DEF touch_physics Physics{
                                               density -1
@@ -800,62 +810,6 @@ PROTO NUgus [
                                               children [
                                                 Box {
                                                   size 0.125 0.12 0.01875
-                                                }
-                                              ]
-                                            }
-                                           Transform {
-                                              translation -0.057 0.024 -0.056
-                                              rotation -1.0 0.0 0.0 -1.54
-                                              children [
-                                                Capsule {
-                                                  bottom      TRUE   # {TRUE, FALSE}
-                                                  height      0.001      # [0, inf)
-                                                  radius      0.009      # [0, inf)
-                                                  side        TRUE   # {TRUE, FALSE}
-                                                  top         FALSE  # {TRUE, FALSE}
-                                                  subdivision 12     # [3, inf)
-                                                }
-                                              ]
-                                            }
-                                            Transform {
-                                              translation 0.041 0.025 -0.056
-                                              rotation -1.0 0.0 0.0 -1.54
-                                              children [
-                                                Capsule {
-                                                  bottom      TRUE   # {TRUE, FALSE}
-                                                  height      0.001      # [0, inf)
-                                                  radius      0.009      # [0, inf)
-                                                  side        TRUE   # {TRUE, FALSE}
-                                                  top         FALSE  # {TRUE, FALSE}
-                                                  subdivision 12     # [3, inf)
-                                                }
-                                              ]
-                                            }
-                                            Transform {
-                                              translation -0.057 -0.154 -0.056
-                                              rotation -1.0 0.0 0.0 -1.54
-                                              children [
-                                                Capsule {
-                                                  bottom      TRUE   # {TRUE, FALSE}
-                                                  height      0.001      # [0, inf)
-                                                  radius      0.009      # [0, inf)
-                                                  side        TRUE   # {TRUE, FALSE}
-                                                  top         FALSE  # {TRUE, FALSE}
-                                                  subdivision 12     # [3, inf)
-                                                }
-                                              ]
-                                            }
-                                            Transform {
-                                              translation 0.041 -0.154 -0.056
-                                              rotation -1.0 0.0 0.0 -1.54
-                                              children [
-                                                Capsule {
-                                                  bottom      TRUE   # {TRUE, FALSE}
-                                                  height      0.001      # [0, inf)
-                                                  radius      0.009      # [0, inf)
-                                                  side        TRUE   # {TRUE, FALSE}
-                                                  top         FALSE  # {TRUE, FALSE}
-                                                  subdivision 12     # [3, inf)
                                                 }
                                               ]
                                             }
@@ -1299,62 +1253,6 @@ PROTO NUgus [
                                               children [
                                                 Box {
                                                   size 0.125 0.12 0.01875
-                                                }
-                                              ]
-                                            }
-                                            Transform {
-                                              translation 0.057 0.024 -0.056
-                                              rotation -1.0 0.0 0.0 -1.54
-                                              children [
-                                                Capsule {
-                                                  bottom      TRUE   # {TRUE, FALSE}
-                                                  height      0.001      # [0, inf)
-                                                  radius      0.009      # [0, inf)
-                                                  side        TRUE   # {TRUE, FALSE}
-                                                  top         FALSE  # {TRUE, FALSE}
-                                                  subdivision 12     # [3, inf)
-                                                }
-                                              ]
-                                            }
-                                            Transform {
-                                              translation -0.04 0.025 -0.056
-                                              rotation -1.0 0.0 0.0 -1.54
-                                              children [
-                                                Capsule {
-                                                  bottom      TRUE   # {TRUE, FALSE}
-                                                  height      0.001      # [0, inf)
-                                                  radius      0.009      # [0, inf)
-                                                  side        TRUE   # {TRUE, FALSE}
-                                                  top         FALSE  # {TRUE, FALSE}
-                                                  subdivision 12     # [3, inf)
-                                                }
-                                              ]
-                                            }
-                                            Transform {
-                                              translation -0.04 -0.154 -0.056
-                                              rotation -1.0 0.0 0.0 -1.54
-                                              children [
-                                                Capsule {
-                                                  bottom      TRUE   # {TRUE, FALSE}
-                                                  height      0.001      # [0, inf)
-                                                  radius      0.009      # [0, inf)
-                                                  side        TRUE   # {TRUE, FALSE}
-                                                  top         FALSE  # {TRUE, FALSE}
-                                                  subdivision 12     # [3, inf)
-                                                }
-                                              ]
-                                            }
-                                            Transform {
-                                              translation 0.057 -0.154 -0.056
-                                              rotation -1.0 0.0 0.0 -1.54
-                                              children [
-                                                Capsule {
-                                                  bottom      TRUE   # {TRUE, FALSE}
-                                                  height      0.001      # [0, inf)
-                                                  radius      0.009      # [0, inf)
-                                                  side        TRUE   # {TRUE, FALSE}
-                                                  top         FALSE  # {TRUE, FALSE}
-                                                  subdivision 12     # [3, inf)
                                                 }
                                               ]
                                             }

--- a/protos/robot/NUgus.proto
+++ b/protos/robot/NUgus.proto
@@ -786,7 +786,7 @@ PROTO NUgus [
                                               ]
                                             }
                                             Transform {
-                                              translation -0.011 -0.128 -0.013
+                                              translation -0.011 -0.128 -0.02
                                               rotation 0.0 0.0 1.0 0.0
                                               children [
                                                 Box {


### PR DESCRIPTION
A requirement for playing with our robot in RoboCup 2021. Moves bounding objects on feet so they don't touch the cleats. Puts capsule bounding boxes on touch sensors that cover the cleats.