### PR TITLE
Fix the NUgus robot's texture path

### DIFF
--- a/protos/robot/NUgus/NUgus.proto
+++ b/protos/robot/NUgus/NUgus.proto
@@ -13,7 +13,7 @@ PROTO NUgus [
   field  SFBool      supervisor           FALSE              # Is `Robot.supervisor`.
   field  SFBool      synchronization      TRUE               # Is `Robot.synchronization`.
   field  SFBool      selfCollision        TRUE               # Is `Robot.selfCollision`.
-  field  MFString    robotTexture         "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture         "./NUgus_textures/NUgus_base_color.jpg"
   # MOTOR PARAMETER: See section 2. of docs/Robot_Model_RoboCup_2021 for more information
   field  SFFloat     MX64-torque          7.30
   field  SFFloat     MX64-vel             8.17

--- a/protos/robot/NUgus/NUgus_mesh/NUgusMain.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgusMain.proto
@@ -13,7 +13,7 @@ PROTO NUgusMain [
   field  SFBool      supervisor           FALSE              # Is `Robot.supervisor`.
   field  SFBool      synchronization      TRUE               # Is `Robot.synchronization`.
   field  SFBool      selfCollision        TRUE               # Is `Robot.selfCollision`.
-  field  MFString    robotTexture         "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture         "./NUgus_textures/NUgus_base_color.jpg"
   # MOTOR PARAMETER: See section 2. of docs/Robot_Model_RoboCup_2021 for more information
   field  SFFloat     MX64-torque          7.30
   field  SFFloat     MX64-vel             8.17

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_headMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_headMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_headMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_left_ankleMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_left_ankleMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_left_ankleMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_left_footMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_left_footMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_left_footMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_left_hip_rollMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_left_hip_rollMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_left_hip_rollMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_left_hip_yawMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_left_hip_yawMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_left_hip_yawMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_left_lower_armMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_left_lower_armMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_left_lower_armMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_left_lower_legMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_left_lower_legMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_left_lower_legMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_left_shoulderMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_left_shoulderMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_left_shoulderMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_left_upper_armMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_left_upper_armMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_left_upper_armMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_left_upper_legMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_left_upper_legMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_left_upper_legMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_neckMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_neckMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_neckMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_right_ankleMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_right_ankleMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_right_ankleMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_right_footMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_right_footMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_right_footMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_right_hip_rollMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_right_hip_rollMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_right_hip_rollMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_right_hip_yawMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_right_hip_yawMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_right_hip_yawMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_right_lower_armMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_right_lower_armMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_right_lower_armMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_right_lower_legMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_right_lower_legMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_right_lower_legMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_right_shoulderMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_right_shoulderMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_right_shoulderMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_right_upper_armMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_right_upper_armMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_right_upper_armMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_right_upper_legMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_right_upper_legMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_right_upper_legMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/protos/robot/NUgus/NUgus_mesh/NUgus_torsoMesh.proto
+++ b/protos/robot/NUgus/NUgus_mesh/NUgus_torsoMesh.proto
@@ -5,7 +5,7 @@
 # Extracted from: NUgus.urdf
 
 PROTO NUgus_torsoMesh [
-  field  MFString    robotTexture    "robot/NUgus/NUgus_textures/NUgus_base_color.jpg"
+  field  MFString    robotTexture    "./NUgus_textures/NUgus_base_color.jpg"
 ]
 {
   Shape {

--- a/worlds/vision_collection.wbt
+++ b/worlds/vision_collection.wbt
@@ -67,9 +67,6 @@ DEF RED_1 Darwin-opHinge2Seg {
 }
 DEF RED_2 NUgus {
   translation -2.207 -0.71576 0.517
-  robotTexture [
-    "robot/NUgus_textures/NUgus_base_color.jpg"
-  ]
   name "red player 2"
   controller "collect_vision_data"
   controllerArgs [
@@ -101,9 +98,6 @@ DEF RED_4 Wolfgang {
 }
 DEF BLUE_1 NUgus {
   translation 2.688 -0.3985 0.5249
-  robotTexture [
-    "robot/NUgus_textures/NUgus_base_color.jpg"
-  ]
   name "blue player 1"
   controller "collect_vision_data"
   controllerArgs [


### PR DESCRIPTION
It was relative to the protos folder rather than the proto itself. This caused issues in the RoboCup world because the location of the proto there was in the first level of the protos folder, whereas in our proto folder it's under a robot folder.

This PR changes it so the textures are relative to the main proto, `NUgus.proto`.