### PR TITLE
Removes the webots folder from formatting

### DIFF
--- a/scripts/format.py
+++ b/scripts/format.py
@@ -47,7 +47,8 @@ def run(**kwargs):
     os.chdir(b.project_dir)
 
     # Use git to get all of the files that are committed to the repository
-    files = check_output(["git", "ls-files"]).decode("utf-8")
+    # Do not format files in the webots directory
+    files = check_output(["git", "ls-files", "--", ".", ":!:webots/*"]).decode("utf-8")
 
     with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
         for r in pool.imap_unordered(partial(_do_format), files.splitlines()):


### PR DESCRIPTION
`./b format` currently tries formatting all files in NUWebots, including those in `NUWebots/webots/`. This folder isn't our code, it's a submodule containing the Webots simulator code. We don't want to format files in this folder.

This PR updates the format script so it only formats our files and ignores the `webots` folder.