### PR TITLE
Add live Webots vision error testing (goal detection) 

### DIFF
--- a/nuwebots/controllers/nugus_controller/CMakeLists.txt
+++ b/nuwebots/controllers/nugus_controller/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(nugus_controller SYSTEM PRIVATE "${PROJECT_BINARY_DIR
 # Use webots, Eigen and protobuf libraries
 target_link_libraries(nugus_controller PRIVATE webots::webots)
 target_link_libraries(nugus_controller PRIVATE Eigen3::Eigen)
+# Link against the protobuf-lite target (this will also add any necessary include directories to our target)
 target_link_libraries(nugus_controller PRIVATE protobuf::libprotobuf-lite)
 
 # Generate binary in controller source directory

--- a/nuwebots/shared/message/messages.proto
+++ b/nuwebots/shared/message/messages.proto
@@ -30,6 +30,12 @@ message Vector3 {
     double Z = 3;
 }
 
+message fvec3 {
+    float x = 1;
+    float y = 2;
+    float z = 3;
+}
+
 message PositionSensorMeasurement {
     string name  = 1;
     double value = 2;
@@ -92,6 +98,13 @@ message OdometryGroundTruth {
     mat4 Htw = 2;
 }
 
+message VisionGroundTruth {
+    /// Indicates if this message exists
+    bool exists = 1;
+    /// Vector from the world to the ball in world space.
+    fvec3 rBWw = 2;
+}
+
 message mat4 {
     vec4 x = 1;
     vec4 y = 2;
@@ -110,18 +123,19 @@ message SensorMeasurements {
     // simulation time stamp at which the measurements were performed expressed in [ms] from the start of the connection
     uint32 time = 1;
     // real unix time stamp at which the measurements were performed in [ms]
-    uint64                             real_time             = 2;
-    repeated Message                   messages              = 3;
-    repeated AccelerometerMeasurement  accelerometers        = 4;
-    repeated BumperMeasurement         bumpers               = 5;
-    repeated CameraMeasurement         cameras               = 6;
-    repeated ForceMeasurement          forces                = 7;
-    repeated Force3DMeasurement        force3ds              = 8;
-    repeated Force6DMeasurement        force6ds              = 9;
-    repeated GyroMeasurement           gyros                 = 10;
-    repeated PositionSensorMeasurement position_sensors      = 11;
+    uint64                             real_time        = 2;
+    repeated Message                   messages         = 3;
+    repeated AccelerometerMeasurement  accelerometers   = 4;
+    repeated BumperMeasurement         bumpers          = 5;
+    repeated CameraMeasurement         cameras          = 6;
+    repeated ForceMeasurement          forces           = 7;
+    repeated Force3DMeasurement        force3ds         = 8;
+    repeated Force6DMeasurement        force6ds         = 9;
+    repeated GyroMeasurement           gyros            = 10;
+    repeated PositionSensorMeasurement position_sensors = 11;
     // NUbots-specific data. Set to 100 in case other data is added in by the RoboCup TC
-    OdometryGroundTruth                odometry_ground_truth = 100;
+    OdometryGroundTruth odometry_ground_truth = 100;
+    VisionGroundTruth   vision_ground_truth   = 101;
 }
 
 message MotorPosition {

--- a/nuwebots/worlds/kid.wbt
+++ b/nuwebots/worlds/kid.wbt
@@ -43,10 +43,10 @@ TexturedBackground {
 TexturedBackgroundLight {
   texture "stadium_dry"
 }
-RobocupSoccerField {
+DEF FIELD RobocupSoccerField {
   size "kid"
 }
-RobocupSoccerBall {
+DEF BALL RobocupSoccerBall {
   translation 0 -1.2605840975378444e-07 0.07852943586495187
   rotation 0.9999999999999999 0 0 1.8715596617048374e-06
 }


### PR DESCRIPTION
### Webots vision benchmarking for goal detection

- Adds message to support goal detection benchmarking using groundtruth data from webots.

https://github.com/NUbots/NUbots/pull/988/