### PR TITLE
Adds a dockerfile for webots with nuwebots and robocup environments

### DIFF
--- a/webots-docker/Dockerfile
+++ b/webots-docker/Dockerfile
@@ -1,0 +1,63 @@
+ARG BASE_IMAGE=nvidia/cuda:11.8.0-base-ubuntu22.04
+FROM ${BASE_IMAGE} AS downloader
+
+# Determine Webots version to be used and set default argument
+ARG WEBOTS_VERSION=R2022b
+ARG WEBOTS_PACKAGE_PREFIX=
+
+# Disable dpkg/gdebi interactive dialogs
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install --yes wget bzip2 && rm -rf /var/lib/apt/lists/ && \
+ wget https://github.com/cyberbotics/webots/releases/download/$WEBOTS_VERSION/webots-$WEBOTS_VERSION-x86-64$WEBOTS_PACKAGE_PREFIX.tar.bz2 && \
+ tar xjf webots-*.tar.bz2 && rm webots-*.tar.bz2
+
+FROM ${BASE_IMAGE}
+
+# Disable dpkg/gdebi interactive dialogs
+ENV DEBIAN_FRONTEND=noninteractive
+
+
+# Install Webots runtime dependencies
+RUN apt-get update && apt-get install --yes wget xvfb git python3-pip sudo && rm -rf /var/lib/apt/lists/ && \
+  wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh && \
+  chmod +x linux_runtime_dependencies.sh && ./linux_runtime_dependencies.sh && rm ./linux_runtime_dependencies.sh
+
+# Install NUWebots dependencies
+RUN wget https://raw.githubusercontent.com/NUbots/NUWebots/main/webots-docker/dependencies.sh && \
+ chmod +x dependencies.sh && ./dependencies.sh && rm ./dependencies.sh && rm -rf /var/lib/apt/lists/
+
+# Install Webots
+WORKDIR /usr/local
+COPY --from=downloader /webots /usr/local/webots/
+ENV QTWEBENGINE_DISABLE_SANDBOX=1
+ENV WEBOTS_HOME /usr/local/webots
+ENV PATH /usr/local/webots:${PATH}
+
+# Enable OpenGL capabilities
+ENV NVIDIA_DRIVER_CAPABILITIES=graphics
+
+RUN useradd -ms /bin/bash webots && usermod -aG sudo webots && echo "webots ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
+ENV HOME=/home/webots
+USER webots
+
+WORKDIR $HOME
+
+# Build the latest version of the RoboCup Humanoid TC fork of GameController
+RUN git clone https://github.com/RoboCup-Humanoid-TC/GameController ./GameController && cd GameController && ant
+
+# Build the robocup controllers
+RUN git clone https://github.com/RoboCup-Humanoid-TC/hlvs_webots.git ./hlvs_webots && \
+ pip3 install -r ./hlvs_webots/controllers/referee/requirements.txt && make -j$(nproc) -C ./hlvs_webots
+
+# Set environment variables for GameController
+ENV GAME_CONTROLLER_HOME=${HOME}/GameController JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+# Install the NUbots-developed environment
+RUN git clone https://github.com/NUbots/NUWebots.git ./NUWebots && cd ./NUWebots && pip3 install -r ./requirements.txt && \
+ ./b configure -- -DENABLE_CLANG_TIDY=OFF && ./b build
+ 
+RUN wget https://raw.githubusercontent.com/NUbots/NUWebots/main/webots-docker/docker-config.py
+
+# Configure robocup game.json file based on environment variables
+CMD ["/bin/bash", "-c", "python3 docker-config.py ${HOME}/hlvs_webots/controllers/referee/game.json;rm docker-config.py;bash"]

--- a/webots-docker/dependencies.sh
+++ b/webots-docker/dependencies.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+apt-get update
+apt-get install -y ant cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen3-dev libyaml-cpp-dev ninja-build clang-tidy python3-dev libjpeg9-dev

--- a/webots-docker/docker-config.py
+++ b/webots-docker/docker-config.py
@@ -1,0 +1,17 @@
+import json, os, sys
+
+TEAM_NAME = os.environ.get('TEAM_NAME')
+ROBOT_HOST = os.environ.get('ROBOT_HOST')
+
+print(type(ROBOT_HOST))
+
+filename = sys.argv[1]
+
+with open(filename, 'r') as f:
+    game_config = json.load(f)
+
+if TEAM_NAME: game_config['red']['config'] = TEAM_NAME + '.json'
+if ROBOT_HOST: game_config['red']['hosts'].append(ROBOT_HOST)
+
+with open(filename, 'w') as f:
+    json.dump(game_config, f, indent=2)


### PR DESCRIPTION
## Requirements:
1. Host must be using X window server
2. host must be configured to allow local connections on the host machine. To do this, run `xhost +local:root`. To undo this run `xhost -local:root`.
3. For GPU acceleration the host computer must be using a NVIDIA graphics card and have nvidia-container-toolkit installed. `nvidia-container-toolkit` is available as an Ubuntu package and is on the AUR. Webots recommends using `nvidia-docker2` instead, but as far as I can tell this is deprecated.

## Notes:
1. The links on lines 27 and 60 reference files in this PR. For testing replace replace `main` with `williamson/webots-docker`.
2. Using docker for gui applications seems to have some fairly unpredictable problems. If the benefits of this docker image are ease-of-use and standardisation, these problems probably limit its usefulness significantly.
3. Most of this is from the cyberbotics [webots-docker ](https://github.com/cyberbotics/webots-docker)repo

## Running:
1. Build the image. There are arguments for building with different webots or ubuntu versions, but the defaults should be fine for nubots / robocup.
2. Find the ip of the container running nubots code on the host machine (I've just been using `ip addr` to get the address of the docker network device. `docker network inspect bridge` also works).
3. To run without gpu acceleration or ip whitelist and team name configured use `docker run -it -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:rw nuwebots`
4. To run with GPU acceleration and configure with nubots team name and ip whitelist use `docker run --gpus=all -it -e DISPLAY --env TEAM_NAME=teams/nubots --env ROBOT_HOST=ip address from step 2 -v /tmp/.X11-unix:/tmp/.X11-unix:rw nuwebots`
5. Run webots in the container with world file as normal. Currently working with `webots ~/hlvs_webots/worlds/robocup.wbt `.

## Connecting with nubots robot code:
1. Get the ip from the webots docker container either by running hostname -i in the container or with `docker container inspect <container id> | grep IPAddress on` the host and enter in `./b edit config/Webots` as normal.

## Problems:
1. I'm not sure what the typical use case is for the nubots developed webots environment. I can run the world file as described in the [nubook page](https://nubook.nubots.net/guides/tools/webots-setup#runnypicalling-a-nubots-environment ). but I don't know how connecting to the robot would typically work, so I haven't been able to do it here.