### PR TITLE
Use port 10001 by default in Kid world, to standardise with RoboCup 

### DIFF
--- a/worlds/kid.wbt
+++ b/worlds/kid.wbt
@@ -74,7 +74,7 @@ DEF BLUE_1 NUgus {
   controller "nugus_controller"
   controllerArgs [
     # TCP port to listen on
-    "10020"
+    "10001"
     # Number of hosts
     "1"
     # Host address


### PR DESCRIPTION
When using RoboCup, the first red robot is on port 10001. In the kid world, we've had 10020 as the port. This is really annoying because we have to keep switching. This PR standardises it so it's using 10001. 

Goes with NUbots/NUbots#1086.