### PR TITLE
Reduce webots camera fps

### DIFF
--- a/controllers/nugus_controller/nugus_controller.cpp
+++ b/controllers/nugus_controller/nugus_controller.cpp
@@ -960,7 +960,7 @@ double PlayerServer::budget_ms            = 1.0;
 double PlayerServer::team_network_quota   = 350.0;
 double PlayerServer::window_duration      = 1.0;
 int PlayerServer::nb_robots_in_team       = 4;
-int PlayerServer::camera_min_time_step    = 16;
+int PlayerServer::camera_min_time_step    = 40;
 double PlayerServer::team_rendering_quota = 350.0;
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
This PR reduces camera FPS in webots to 25 FPS to match current real hardware settings, this is to help reduce any sim2real gap related to camera frame rate when developing algorithms reliant on images. https://github.com/NUbots/NUbots/pull/1571